### PR TITLE
Update Builder for Compiling a Teensy Program with <arm_math.h> and Floating Point Libraries

### DIFF
--- a/builder/main.py
+++ b/builder/main.py
@@ -137,9 +137,10 @@ elif "BOARD" in env and env.BoardConfig().get("build.core") == "teensy3":
             "--specs=nano.specs"
         ],
         LIBS=[
-            "c", "gcc", "arm_cortex%sl_math" %
+            "c", "gcc", "arm_cortex%sl%s_math" %
             ("M4" if env.BoardConfig().get(
-                "build.cpu") == "cortex-m4" else "M0")
+                "build.cpu") == "cortex-m4" else "M0", 
+             "f" if (env.BoardConfig().get("name") == "Teensy 3.6") or (env.BoardConfig().get("name") == "Teensy 3.5") else "")
         ],
         BUILDERS=dict(
             ElfToBin=Builder(


### PR DESCRIPTION
So I've been trying to get the Teensy 3.6 to compile using floating point functions like "arm_matrix_add_f32" and kept getting this build error

```
/lib/libSPI.a ".pioenvs/teensy36/lib/libSparkFun DS3234 Real-Time Clock _RTC_.a" -Wl,--end-group
/home/ashwin/.platformio/packages/toolchain-gccarmnoneeabi/bin/../lib/gcc/arm-none-eabi/4.8.4/../../../../arm-none-eabi/bin/ld: error: .pioenvs/teensy36/firmware.elf us
es VFP register arguments, /home/ashwin/.platformio/packages/toolchain-gccarmnoneeabi/bin/../lib/gcc/arm-none-eabi/4.8.4/../../../../arm-none-eabi/lib/libarm_cortexM4l_
math.a(arm_mat_add_f32.o) does not
/home/ashwin/.platformio/packages/toolchain-gccarmnoneeabi/bin/../lib/gcc/arm-none-eabi/4.8.4/../../../../arm-none-eabi/bin/ld: failed to merge target specific data of
file /home/ashwin/.platformio/packages/toolchain-gccarmnoneeabi/bin/../lib/gcc/arm-none-eabi/4.8.4/../../../../arm-none-eabi/lib/libarm_cortexM4l_math.a(arm_mat_add_f32
.o)
collect2: error: ld returned 1 exit status
*** [.pioenvs/teensy36/firmware.elf] Error 1
```

After digging around for a bit I found that the error is because of lines 139-143 in the `platform-teensy/builder/main.py` file.

```Python
        LIBS=[
            "c", "gcc", "arm_cortex%sl_math" %
            ("M4" if env.BoardConfig().get(
                "build.cpu") == "cortex-m4" else "M0")
        ],
```
According to the boards.txt file, both Teensy 3.5 and 3.6 links against libarm_cortexM4lf_math (teensy36.build.flags.libs=-larm_cortexM4lf_math -lm) for the floating point instructions in <arm_math> to work. I modified the line in the Python code to `arm_cortex%slf_math` and it compiled fine. 

I modified the main.py file so that it checks if the board is Teensy 3.5 or Teensy 3.6 and links the correct floating point library instead. 

I think this will be helpful. :)
