### PR TITLE
Add flags to include libc to Teensy 3.X

### DIFF
--- a/boards/teensy30.json
+++ b/boards/teensy30.json
@@ -5,7 +5,7 @@
     },
     "core": "teensy3",
     "cpu": "cortex-m4",
-    "extra_flags": "-D__MK20DX128__ -DARDUINO_TEENSY30",
+    "extra_flags": "-D__MK20DX128__ -DARDUINO_TEENSY30 -llibc -lc",
     "f_cpu": "48000000L",
     "mcu": "mk20dx128"
   },

--- a/boards/teensy31.json
+++ b/boards/teensy31.json
@@ -5,7 +5,7 @@
     },
     "core": "teensy3",
     "cpu": "cortex-m4",
-    "extra_flags": "-D__MK20DX256__ -DARDUINO_TEENSY31",
+    "extra_flags": "-D__MK20DX256__ -DARDUINO_TEENSY31 -llibc -lc",
     "f_cpu": "72000000L",
     "mcu": "mk20dx256"
   },

--- a/boards/teensy35.json
+++ b/boards/teensy35.json
@@ -5,7 +5,7 @@
     },
     "core": "teensy3",
     "cpu": "cortex-m4",
-    "extra_flags": "-D__MK64FX512__ -DARDUINO_TEENSY35",
+    "extra_flags": "-D__MK64FX512__ -DARDUINO_TEENSY35 -llibc -lc",
     "f_cpu": "120000000L",
     "mcu": "mk64fx512"
   },

--- a/boards/teensy36.json
+++ b/boards/teensy36.json
@@ -5,7 +5,7 @@
     },
     "core": "teensy3",
     "cpu": "cortex-m4",
-    "extra_flags": "-D__MK66FX1M0__ -DARDUINO_TEENSY36",
+    "extra_flags": "-D__MK66FX1M0__ -DARDUINO_TEENSY36 -llibc -lc",
     "f_cpu": "180000000L",
     "mcu": "mk66fx1m0"
   },


### PR DESCRIPTION
This fixes the issue in this question: https://stackoverflow.com/questions/55784235/platformio-linker-error-when-including-functional