### PR TITLE
Add teensy_secure support

### DIFF
--- a/builder/main.py
+++ b/builder/main.py
@@ -129,6 +129,8 @@ elif "BOARD" in env and build_core in ("teensy3", "teensy4"):
     )
 
     if build_core == "teensy4":
+        # Get the key and default to an empty string
+        custom_secure_key = env.GetProjectConfig().get("env:" + env["PIOENV"], "custom_secure_key", "")
         env.Append(
             BUILDERS=dict(
                 HexToEhex=Builder(
@@ -136,7 +138,8 @@ elif "BOARD" in env and build_core in ("teensy3", "teensy4"):
                         "$TEENSYSECURE",
                         "encrypthex",
                         board_config.id.upper(),
-                        "$SOURCES"
+                        "$SOURCES",
+                        custom_secure_key
                     ]), "Encrypting $TARGET"),
                     suffix=".ehex"
                 )

--- a/builder/main.py
+++ b/builder/main.py
@@ -136,13 +136,19 @@ elif "BOARD" in env and build_core in ("teensy3", "teensy4"):
         else:
             encrypt_message = "Encrypting $TARGET with default key"
 
+        # Choose the correct board name for teensy_secure
+        if board_config.id == "teensymm":
+            board_name = "TEENSY_MICROMOD"
+        else:
+            board_name = board_config.id.upper()
+
         env.Append(
             BUILDERS=dict(
                 HexToEhex=Builder(
                     action=env.VerboseAction(" ".join([
                         "$TEENSYSECURE",
                         "encrypthex",
-                        board_config.id.upper(),
+                        board_name,
                         "$SOURCES",
                         custom_secure_key
                     ]), encrypt_message),

--- a/builder/main.py
+++ b/builder/main.py
@@ -96,7 +96,8 @@ elif "BOARD" in env and build_core in ("teensy3", "teensy4"):
         OBJCOPY="arm-none-eabi-objcopy",
         RANLIB="arm-none-eabi-gcc-ranlib",
         SIZETOOL="arm-none-eabi-size",
-        SIZEPRINTCMD="$SIZETOOL -B -d $SOURCES"
+        SIZEPRINTCMD="$SIZETOOL -B -d $SOURCES",
+        TEENSYSECURE="teensy_secure"
     )
 
     env.Append(
@@ -126,6 +127,21 @@ elif "BOARD" in env and build_core in ("teensy3", "teensy4"):
             )
         )
     )
+
+    if build_core == "teensy4":
+        env.Append(
+            BUILDERS=dict(
+                HexToEhex=Builder(
+                    action=env.VerboseAction(" ".join([
+                        "$TEENSYSECURE",
+                        "encrypthex",
+                        board_config.id.upper(),
+                        "$SOURCES"
+                    ]), "Encrypting $TARGET"),
+                    suffix=".ehex"
+                )
+            )
+        )
 
     if not env.get("PIOFRAMEWORK"):
         env.SConscript("frameworks/_bare_arm.py")
@@ -174,6 +190,8 @@ if "nobuild" in COMMAND_LINE_TARGETS:
 else:
     target_elf = env.BuildProgram()
     target_firm = env.ElfToHex(join("$BUILD_DIR", "${PROGNAME}"), target_elf)
+    if build_core == "teensy4":
+        target_firm = env.HexToEhex(join("$BUILD_DIR", "${PROGNAME}"), target_firm)
     env.Depends(target_firm, "checkprogsize")
 
 AlwaysBuild(env.Alias("nobuild", target_firm))

--- a/builder/main.py
+++ b/builder/main.py
@@ -130,7 +130,7 @@ elif "BOARD" in env and build_core in ("teensy3", "teensy4"):
 
     if build_core == "teensy4":
         # Get the key and default to an empty string
-        custom_secure_key = env.GetProjectConfig().get("env:" + env["PIOENV"], "custom_secure_key", "")
+        custom_secure_key = env.GetProjectOption("custom_secure_key", "")
         if custom_secure_key:
             encrypt_message = f"Encrypting $TARGET with key at {custom_secure_key}"
         else:

--- a/builder/main.py
+++ b/builder/main.py
@@ -131,6 +131,11 @@ elif "BOARD" in env and build_core in ("teensy3", "teensy4"):
     if build_core == "teensy4":
         # Get the key and default to an empty string
         custom_secure_key = env.GetProjectConfig().get("env:" + env["PIOENV"], "custom_secure_key", "")
+        if custom_secure_key:
+            encrypt_message = f"Encrypting $TARGET with key at {custom_secure_key}"
+        else:
+            encrypt_message = "Encrypting $TARGET with default key"
+
         env.Append(
             BUILDERS=dict(
                 HexToEhex=Builder(
@@ -140,7 +145,7 @@ elif "BOARD" in env and build_core in ("teensy3", "teensy4"):
                         board_config.id.upper(),
                         "$SOURCES",
                         custom_secure_key
-                    ]), "Encrypting $TARGET"),
+                    ]), encrypt_message),
                     suffix=".ehex"
                 )
             )


### PR DESCRIPTION
This is a first attempt.

Some notes:
1. I'm not quite sure how to use the .hex file name and not the .ehex file name if `teensy_secure` fails to encrypt. While it still works because the `teensy_secure` program, when told to upload a '.ehex' file, will find the '.hex' file, I don't like how it still says `Uploading .pio/build/teensy41/firmware.ehex`.
2. I haven't tested this on Windows or Linux.

Inspiration for this PR found here:
1. #93 
2. @GoobyCorp's fork: https://github.com/GoobyCorp/platform-teensy

Resolves #93